### PR TITLE
Fix encoding of strings of length 256 (or 2^16 or 2^32)

### DIFF
--- a/cbor.el
+++ b/cbor.el
@@ -160,7 +160,7 @@ Default to big endian unless LITTLE is non-nil."
 
 (defun cbor-uint-needed-size (uint)
   "Return standard required sized to store UINT up to 8 bytes."
-  (pcase (ceiling (log uint 256))
+  (pcase (ceiling (log (+ 1 uint) 256))
     (1 1)
     (2 2)
     ((or 3 4) 4)

--- a/tests/encodings-test.el
+++ b/tests/encodings-test.el
@@ -81,7 +81,10 @@
                  "c074323031332d30332d32315432303a30343a30305a" ,(cbor-tag-create :number 0 :content "2013-03-21T20:04:00Z")
                  "c11a514b67b0"  ,(cbor-tag-create :number 1 :content 1363896240)
                  "f4" :false
-                 "f5" t)))
+                 "f5" t
+                 ;; length of 256, requires two bytes to encode the length
+                 "79010078787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878"
+                 "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx")))
     (cl-loop for (input expected) on specs by #'cddr do
              (should (equal (cbor->elisp input) expected))
              (should (equal (encode-hex-string (cbor<-elisp expected)) input)))))


### PR DESCRIPTION
I hope this is the right place to submit a patch for the CBOR package found on MELPA.

There is currently an issue in cbor.el where strings with a length of exactly 256 are encoded as if they had a length of 0. This causes the UTF-8 bytes of the string to be interpreted as CBOR bytes, leading to a garbled message.

The greatest number that can be encoded in a single byte is 255, for a string of length 256 we need a second byte to encode the length.

- [cbor playground 256 byte string](https://cbor.me/?diag=%22xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx%22) (expected)
- [cbor playground of current cbor.el output](https://cbor.me/?bytes=780078787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878) (actual)